### PR TITLE
Added a failing testcase.

### DIFF
--- a/reverse_unique/fields.py
+++ b/reverse_unique/fields.py
@@ -1,4 +1,3 @@
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import (
     ReverseSingleRelatedObjectDescriptor, ForeignObject)
 
@@ -18,6 +17,7 @@ class ReverseUniqueDescriptor(ReverseSingleRelatedObjectDescriptor):
             setattr(instance, self.cache_name, None)
             return None
 
+
 class ReverseUnique(ForeignObject):
     requires_unique_target = False
 
@@ -32,18 +32,74 @@ class ReverseUnique(ForeignObject):
 
     def resolve_related_fields(self):
         if self.through is None:
+            possible_models = [self.model] + [m for m in self.model.__mro__ if hasattr(m, '_meta')]
             possible_targets = [f for f in self.rel.to._meta.concrete_fields
-                                if f.rel and f.rel.to == self.model]
+                                if f.rel and f.rel.to in possible_models]
             if len(possible_targets) != 1:
                 raise Exception("Found %s target fields instead of one, the fields found were %s."
                                 % (len(possible_targets), [f.name for f in possible_targets]))
             related_field = possible_targets[0]
         else:
             related_field = self.model._meta.get_field_by_name(self.through)[0].field
+        if related_field.rel.to._meta.concrete_model != self.model._meta.concrete_model:
+            # We have found a foreign key pointing to parent model.
+            # This will only work if the fk is pointing to a value
+            # that can be found from the child model, too. This is
+            # the case only when we have parent pointer in child
+            # pointing to same field as the found foreign key is
+            # pointing to. Lets find this out. And, lets handle
+            # only the single column case for now.
+            if len(related_field.to_fields) > 1:
+                raise ValueError(
+                    "FIXME: No support for multi-column joins in parent join case."
+                )
+            to_fields = self._find_parent_link(related_field)
+        else:
+            to_fields = [f.name for f in related_field.foreign_related_fields]
         del self.through
-        self.to_fields = related_field.from_fields
-        self.from_fields = related_field.to_fields
-        return related_field.reverse_related_fields
+        self.to_fields = [f.name for f in related_field.local_related_fields]
+        self.from_fields = to_fields
+        return super(ReverseUnique, self).resolve_related_fields()
+
+    def _find_parent_link(self, related_field):
+        """
+        Find a field containing the value of related_field in local concrete
+        fields or raise an error if the value isn't available in local table.
+
+        Technical reason for this is that parent model joining is done later
+        than filter join production, and that means proucing a join against
+        parent tables will not work.
+        """
+        # The hard part here is to verify that the value in fact can be found
+        # from local field. Lets first build the ancestor link chain
+        ancestor_links = []
+        curr_model = self.model
+        while True:
+            found_link = curr_model._meta.get_ancestor_link(related_field.rel.to)
+            if not found_link:
+                # OK, we found to parent model. Lets check that the pointed to
+                # field contains the correct value.
+                last_link = ancestor_links[-1]
+                if last_link.foreign_related_fields != related_field.foreign_related_fields:
+                    curr_opts = curr_model._meta
+                    rel_opts = self.rel.to._meta
+                    opts = self.model._meta
+                    raise ValueError(
+                        "The field(s) %s of model %s.%s which %s.%s.%s is "
+                        "pointing to cannot be found from %s.%s. "
+                        "Add ReverseUnique to parent instead." % (
+                            ', '.join([f.name for f in related_field.foreign_related_fields]),
+                            curr_opts.app_label, curr_opts.object_name,
+                            rel_opts.app_label, rel_opts.object_name, related_field.name,
+                            opts.app_label, opts.object_name
+                        )
+                    )
+                break
+            if ancestor_links:
+                assert found_link.local_related_fields == ancestor_links[-1].foreign_related_fields
+            ancestor_links.append(found_link)
+            curr_model = found_link.rel.to
+        return [self.model._meta.get_ancestor_link(related_field.rel.to).name]
 
     def get_extra_restriction(self, where_class, alias, related_alias):
         qs = self.rel.to.objects.filter(self.filters).query

--- a/reverse_unique/test_models.py
+++ b/reverse_unique/test_models.py
@@ -5,6 +5,7 @@ from django.db.models import Q, F
 from django.utils.translation import get_language
 from reverse_unique import ReverseUnique
 
+
 class Article(models.Model):
     pub_date = models.DateField()
     active_translation = ReverseUnique(
@@ -13,11 +14,13 @@ class Article(models.Model):
     class Meta:
         app_label = 'reverse_unique'
 
+
 class Lang(models.Model):
     code = models.CharField(max_length=2, primary_key=True)
 
     class Meta:
         app_label = 'reverse_unique'
+
 
 class ArticleTranslation(models.Model):
     article = models.ForeignKey(Article)
@@ -45,6 +48,7 @@ class DefaultTranslationArticle(models.Model):
     class Meta:
         app_label = 'reverse_unique'
 
+
 class DefaultTranslationArticleTranslation(models.Model):
     article = models.ForeignKey(DefaultTranslationArticle)
     lang = models.CharField(max_length=2)
@@ -63,6 +67,7 @@ class Guest(models.Model):
     class Meta:
         app_label = 'reverse_unique'
 
+
 class Room(models.Model):
     current_reservation = ReverseUnique(
         "Reservation", through='reservations',
@@ -71,6 +76,7 @@ class Room(models.Model):
 
     class Meta:
         app_label = 'reverse_unique'
+
 
 class Reservation(models.Model):
     room = models.ForeignKey(Room, related_name='reservations')
@@ -81,11 +87,14 @@ class Reservation(models.Model):
     class Meta:
         app_label = 'reverse_unique'
 
+
 class Parent(models.Model):
     rel1 = ReverseUnique("Rel1", filters=Q(f1="foo"))
+    uniq_field = models.CharField(max_length=10, unique=True, null=True)
 
     class Meta:
         app_label = 'reverse_unique'
+
 
 class Rel1(models.Model):
     parent = models.ForeignKey(Parent, related_name="rel1list")
@@ -94,15 +103,31 @@ class Rel1(models.Model):
     class Meta:
         app_label = 'reverse_unique'
 
+
 class Child(Parent):
     rel2 = ReverseUnique("Rel2", filters=Q(f1="foo"))
 
     class Meta:
         app_label = 'reverse_unique'
 
+
+class AnotherChild(Child):
+    rel1_child = ReverseUnique("Rel1", filters=Q(f1__startswith="foo"))
+
+    class Meta:
+        app_label = 'reverse_unique'
+
+
 class Rel2(models.Model):
     child = models.ForeignKey(Child, related_name="rel2list")
     f1 = models.CharField(max_length=10)
+
+    class Meta:
+        app_label = 'reverse_unique'
+
+
+class Rel3(models.Model):
+    a_model = models.ForeignKey(Parent, to_field='uniq_field')
 
     class Meta:
         app_label = 'reverse_unique'


### PR DESCRIPTION
Hi there!

I've been watching your project for a couple of weeks since it simplifies a lot of things in a code base of mine but I hit a wall when trying to use it in an inheritance scenario.

As described in the provided testcase I'm trying to reverse through a parent relationship but it looks like the whole query generation gets confused. Apart from the missing field exception I noticed that an `INNER JOIN` is used instead of a `LEFT OUTER` one.

I'm trying to familiarize myself with the Django ORM therefore an hint as where to start looking would be greatly appreciated.
