### PR TITLE
Add support for ReverseUnique(null=True)

### DIFF
--- a/reverse_unique/fields.py
+++ b/reverse_unique/fields.py
@@ -13,9 +13,12 @@ class ReverseUniqueDescriptor(ReverseSingleRelatedObjectDescriptor):
     def __get__(self, instance, *args, **kwargs):
         try:
             return super(ReverseUniqueDescriptor, self).__get__(instance, *args, **kwargs)
-        except self.field.rel.to.DoesNotExist:
+        except self.field.rel.to.DoesNotExist as e:
             setattr(instance, self.cache_name, None)
-            return None
+            if self.field.null:
+                return None
+            else:
+                raise e
 
 
 class ReverseUnique(ForeignObject):
@@ -26,8 +29,8 @@ class ReverseUnique(ForeignObject):
         self.through = kwargs.pop('through', None)
         kwargs['from_fields'] = []
         kwargs['to_fields'] = []
-        kwargs['null'] = True
         kwargs['related_name'] = '+'
+        kwargs.setdefault('null', True)
         super(ReverseUnique, self).__init__(*args, **kwargs)
 
     def resolve_related_fields(self):

--- a/reverse_unique/test_models.py
+++ b/reverse_unique/test_models.py
@@ -10,6 +10,8 @@ class Article(models.Model):
     pub_date = models.DateField()
     active_translation = ReverseUnique(
         "ArticleTranslation", filters=Q(lang=get_language))
+    active_translation_nonnull = ReverseUnique(
+        "ArticleTranslation", filters=Q(lang=get_language), null=False)
 
     class Meta:
         app_label = 'reverse_unique'

--- a/reverse_unique/tests.py
+++ b/reverse_unique/tests.py
@@ -75,6 +75,17 @@ class ReverseUniqueTests(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(a1.active_translation.title, "Title")
 
+    def test_nullable(self):
+        a1 = Article.objects.create(pub_date=datetime.date.today())
+
+        self.assertEqual(a1.active_translation, None)
+
+    def test_non_nullable(self):
+        a1 = Article.objects.create(pub_date=datetime.date.today())
+
+        with self.assertRaises(ArticleTranslation.DoesNotExist):
+            a1.active_translation_nonnull
+
     def test_default_trans_article(self):
         activate('fi')
         a1 = DefaultTranslationArticle.objects.create(


### PR DESCRIPTION
When null=True, accessing a ReverseUnique that doesn't exist should raise DoesNotExist instead of returning None.

I might be missing something here if null=True controls other behavior. I did notice that it generates an inner instead of outer join in select_related. Should this behave like the reverse OneToOne field, where prefetching the reverse relationship generates an outer join but accessing it raises DoesNotExist?