### PR TITLE
Django 1.7+, Tox and TravisCI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = reverse_unique
+branch = 1
+omit = reverse_unique/test*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+
+python:
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+
+env:
+  - DJANGO=1.6
+  - DJANGO=1.7
+  - DJANGO=1.8
+  - DJANGO=master
+
+matrix:
+  include:
+    - python: 2.6
+      env: DJANGO=1.6
+  exclude:
+    - python: 3.4
+      env: DJANGO=1.6
+  allow_failures:
+    - env: DJANGO=master
+
+install:
+  pip install tox coveralls
+
+script:
+  tox -e `python -c 'import sys,os;print("py%d%d-"%sys.version_info[0:2]+os.environ["DJANGO"])'`
+
+after_success: coveralls

--- a/reverse_unique/fields.py
+++ b/reverse_unique/fields.py
@@ -56,7 +56,6 @@ class ReverseUnique(ForeignObject):
             to_fields = self._find_parent_link(related_field)
         else:
             to_fields = [f.name for f in related_field.foreign_related_fields]
-        del self.through
         self.to_fields = [f.name for f in related_field.local_related_fields]
         self.from_fields = to_fields
         return super(ReverseUnique, self).resolve_related_fields()
@@ -124,3 +123,10 @@ class ReverseUnique(ForeignObject):
     def contribute_to_class(self, cls, name):
         super(ReverseUnique, self).contribute_to_class(cls, name)
         setattr(cls, self.name, ReverseUniqueDescriptor(self))
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(ReverseUnique, self).deconstruct()
+        kwargs['filters'] = self.filters
+        if self.through is not None:
+            kwargs['through'] = self.through
+        return name, path, args, kwargs

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+args_are_paths = false
+envlist =
+    py26-{1.6},
+    {py27,py32,py33}-{1.6,1.7,1.8,master},
+    py34-{1.7,1.8,master}
+
+[testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.4
+usedevelop = true
+commands =
+    python -R -Wonce {envbindir}/coverage run testproject/manage.py test -v2 {posargs}
+    coverage report
+deps =
+    coverage
+    1.6: Django>=1.6,<1.7
+    1.7: Django>=1.7,<1.8
+    1.8: Django==1.8c1
+    master: https://github.com/django/django/archive/master.zip


### PR DESCRIPTION
The following commits fix an issue with `ReverseUnique` deconstruction (re-construction actually), add a tox configuration file to run tests against the all the supported Django 1.6+ and Python combination and a TravisCI configuration file to run all the Tox matrix.

Note that the tests against master fail because Django can't be installed from source through pip until @pypi/pip#1473 is fixed. This will require you to register this package on [TravisCI](https://travis-ci.org/repositories) and [Coveralls](http://coveralls.io)