### PR TITLE
CI upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,28 @@ sudo: no
 
 language: python
 
-python:
-  - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
-
 env:
-  - DJANGO=1.7
-  - DJANGO=1.8
-  - DJANGO=master
+  - TOXENV=py27-1.7
+  - TOXENV=py27-1.8
+  - TOXENV=py27-master
+  - TOXENV=py32-1.7
+  - TOXENV=py32-1.8
+  - TOXENV=py33-1.7
+  - TOXENV=py33-1.8
+  - TOXENV=py34-1.7
+  - TOXENV=py34-1.8
+  - TOXENV=py34-master
 
 matrix:
-  exclude:
-    - python: 3.2
-      env: DJANGO=master
+  fast_finish: true
   allow_failures:
-    - env: DJANGO=master
+    - env: TOXENV=py27-master
+    - env: TOXENV=py34-master
 
 install:
   pip install tox coveralls
 
 script:
-  tox -e `python -c 'import sys,os;print("py%d%d-"%sys.version_info[0:2]+os.environ["DJANGO"])'`
+  tox
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: no
+
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,14 @@ python:
   - 3.4
 
 env:
-  - DJANGO=1.6
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=master
 
 matrix:
-  include:
-    - python: 2.6
-      env: DJANGO=1.6
   exclude:
-    - python: 3.4
-      env: DJANGO=1.6
+    - python: 3.2
+      env: DJANGO=master
   allow_failures:
     - env: DJANGO=master
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ deps =
     coverage
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
-    master: https://github.com/django/django/archive/master.zip
+    master: https://github.com/django/django/archive/master.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 args_are_paths = false
 envlist =
-    py26-{1.6},
-    {py27,py32,py33}-{1.6,1.7,1.8,master},
-    py34-{1.7,1.8,master}
+    py32-{1.7,1.8},
+    {py27,py33,py34}-{1.7,1.8,master}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -18,7 +16,6 @@ commands =
     coverage report
 deps =
     coverage
-    1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
     1.8: Django==1.8c1
     master: https://github.com/django/django/archive/master.zip

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,5 @@ commands =
 deps =
     coverage
     1.7: Django>=1.7,<1.8
-    1.8: Django==1.8c1
+    1.8: Django>=1.8,<1.9
     master: https://github.com/django/django/archive/master.zip

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 args_are_paths = false
 envlist =
-    py32-{1.7,1.8},
-    {py27,py33,py34}-{1.7,1.8,master}
+    py27-{1.7,1.8,master},
+    py{32,33}-{1.7,1.8},
+    py34-{1.7,1.8,master}
 
 [testenv]
 basepython =


### PR DESCRIPTION
The following changes remove testing against the now unsupported Django 1.6, make sure 1.8 tests are ran against the latest release and allow master tests to be run on Python 2.